### PR TITLE
feat: make downloads clickable

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,6 @@
 ---
 port: 8080
-scan_interval: 60 # The interval in minutes between scans of the manga library.
+scan_interval: 0 # Minutes between full library scans; 0 disables periodic scans (watcher / manual sync still run).
 database:
   # The path to the SQLite database file.
   path: "./mango.db"

--- a/internal/api/downloader_handlers_test.go
+++ b/internal/api/downloader_handlers_test.go
@@ -159,6 +159,46 @@ func TestHandleGetDownloadQueue(t *testing.T) {
 	if len(items) != 1 {
 		t.Errorf("Expected 1 item in queue, got %d", len(items))
 	}
+	if items[0].LocalChapterID != nil || items[0].LocalFolderID != nil {
+		t.Errorf("expected no local library IDs in JSON when unset, got chapter=%v folder=%v", items[0].LocalChapterID, items[0].LocalFolderID)
+	}
+}
+
+func TestHandleGetDownloadQueue_LocalLibraryIDs(t *testing.T) {
+	server, db := SetupTestServerWithProviders(t)
+	router := server.Router()
+
+	res, err := db.Exec(`INSERT INTO download_queue (series_title, chapter_title, chapter_identifier, provider_id, created_at, status) VALUES ('S', 'Ch', 'cid', 'mockadex', ?, 'completed')`, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, _ := res.LastInsertId()
+	if _, err := db.Exec(`UPDATE download_queue SET local_chapter_id = ?, local_folder_id = ? WHERE id = ?`, 100, 200, id); err != nil {
+		t.Fatal(err)
+	}
+
+	req, _ := http.NewRequest("GET", "/api/downloads/queue", nil)
+	req.AddCookie(testutil.CookieForUser(t, server, "testuser", "password", "user"))
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d, body %s", rr.Code, rr.Body.String())
+	}
+
+	var items []models.DownloadQueueItem
+	if err := json.Unmarshal(rr.Body.Bytes(), &items); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("want 1 item, got %d", len(items))
+	}
+	if items[0].LocalChapterID == nil || *items[0].LocalChapterID != 100 {
+		t.Errorf("local_chapter_id: want 100, got %v", items[0].LocalChapterID)
+	}
+	if items[0].LocalFolderID == nil || *items[0].LocalFolderID != 200 {
+		t.Errorf("local_folder_id: want 200, got %v", items[0].LocalFolderID)
+	}
 }
 
 func TestHandleQueueAction(t *testing.T) {

--- a/internal/assets/migrations/000008_download_queue_local_chapter.down.sql
+++ b/internal/assets/migrations/000008_download_queue_local_chapter.down.sql
@@ -1,0 +1,4 @@
+PRAGMA foreign_keys = ON;
+
+ALTER TABLE download_queue DROP COLUMN local_chapter_id;
+ALTER TABLE download_queue DROP COLUMN local_folder_id;

--- a/internal/assets/migrations/000008_download_queue_local_chapter.up.sql
+++ b/internal/assets/migrations/000008_download_queue_local_chapter.up.sql
@@ -1,0 +1,4 @@
+PRAGMA foreign_keys = ON;
+
+ALTER TABLE download_queue ADD COLUMN local_chapter_id INTEGER;
+ALTER TABLE download_queue ADD COLUMN local_folder_id INTEGER;

--- a/internal/assets/web/static/css/download_manager.css
+++ b/internal/assets/web/static/css/download_manager.css
@@ -109,10 +109,6 @@
   background: rgba(var(--accent-color-rgb), 0.05);
 }
 
-.queue-table tbody tr.queue-row--readable {
-  cursor: pointer;
-}
-
 .queue-table th:nth-child(3),
 .queue-table td:nth-child(3) {
   width: 20%;
@@ -176,7 +172,7 @@
 /* Action Buttons */
 .actions-cell {
   text-align: center;
-  width: 120px;
+  width: 160px;
   white-space: nowrap;
 }
 
@@ -195,6 +191,16 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+}
+
+a.reader-link-btn {
+  text-decoration: none;
+  box-sizing: border-box;
+  vertical-align: middle;
+}
+
+a.reader-link-btn:hover {
+  text-decoration: none;
 }
 
 .action-btn:hover:not(:disabled) {
@@ -281,7 +287,7 @@
   }
 
   .actions-cell {
-    width: 100px;
+    width: 132px;
   }
 
   .action-btn {

--- a/internal/assets/web/static/css/download_manager.css
+++ b/internal/assets/web/static/css/download_manager.css
@@ -109,6 +109,10 @@
   background: rgba(var(--accent-color-rgb), 0.05);
 }
 
+.queue-table tbody tr.queue-row--readable {
+  cursor: pointer;
+}
+
 .queue-table th:nth-child(3),
 .queue-table td:nth-child(3) {
   width: 20%;

--- a/internal/assets/web/static/js/download_manager.js
+++ b/internal/assets/web/static/js/download_manager.js
@@ -9,19 +9,14 @@ document.addEventListener('DOMContentLoaded', async () => {
   const pauseResumeBtn = document.getElementById('pause-resume-btn');
   let ws;
 
-  const applyReaderLinkToRow = (row, chapterId, folderId) => {
-    if (chapterId != null && folderId != null) {
-      row.dataset.chapterId = String(chapterId);
-      row.dataset.folderId = String(folderId);
-      row.classList.add('queue-row--readable');
-      row.title = 'Open in reader';
-    } else {
-      delete row.dataset.chapterId;
-      delete row.dataset.folderId;
-      row.classList.remove('queue-row--readable');
-      row.removeAttribute('title');
-    }
-  };
+  const escapeHtml = str =>
+    String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/"/g, '&quot;');
+
+  const readerHref = (folderId, chapterId) =>
+    `/reader/series/${folderId}/chapters/${chapterId}`;
 
   const renderRow = item => {
     let row = document.getElementById(`item-${item.id}`);
@@ -31,11 +26,18 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
     const statusClass = `status-${item.status.replace(' ', '_').toLowerCase()}`;
 
-    let actionButtons = generateActionCellContent(item.id, item.status);
+    const canRead =
+      item.status === 'completed' &&
+      item.local_chapter_id != null &&
+      item.local_folder_id != null;
+    const fid = canRead ? item.local_folder_id : null;
+    const cid = canRead ? item.local_chapter_id : null;
+
+    let actionButtons = generateActionCellContent(item.id, item.status, fid, cid);
 
     row.innerHTML = `
-      <td title="${item.chapter_title}">${item.chapter_title}</td>
-      <td title="${item.series_title}">${item.series_title}</td>
+      <td title="${escapeHtml(item.chapter_title)}">${escapeHtml(item.chapter_title)}</td>
+      <td title="${escapeHtml(item.series_title)}">${escapeHtml(item.series_title)}</td>
       <td>
           <div class="progress-bar-container">
               <div class="progress-bar" style="width: ${item.progress}%;">${item.progress}%</div>
@@ -46,22 +48,17 @@ document.addEventListener('DOMContentLoaded', async () => {
       <td>${item.provider_id}</td>
       <td class="actions-cell">${actionButtons}</td>
     `;
-    if (
-      item.status === 'completed' &&
-      item.local_chapter_id != null &&
-      item.local_folder_id != null
-    ) {
-      applyReaderLinkToRow(row, item.local_chapter_id, item.local_folder_id);
-    } else {
-      applyReaderLinkToRow(row, null, null);
-    }
     return row;
   };
 
-  const generateActionCellContent = (itemId, status) => {
+  const generateActionCellContent = (itemId, status, folderId, chapterId) => {
+    let readerLink = '';
+    if (status === 'completed' && folderId != null && chapterId != null) {
+      readerLink = `<a class="reader-link-btn action-btn" href="${readerHref(folderId, chapterId)}" aria-label="Open in reader" title="Open in reader"><i class="ph-bold ph-book-open"></i></a>`;
+    }
     let actionButtons = '';
     if (status === 'queued' || status === 'completed') {
-      actionButtons = `<button class="action-btn delete-btn" data-action="delete" data-id="${itemId}" title="Delete">🗑️</button>`;
+      actionButtons = `${readerLink}<button class="action-btn delete-btn" data-action="delete" data-id="${itemId}" title="Delete">🗑️</button>`;
     } else if (status === 'failed') {
       actionButtons = `<button class="action-btn retry-btn" data-action="retry" data-id="${itemId}" title="Retry"><i class="ph-bold ph-arrow-clockwise"></i></button> <button class="action-btn delete-btn" data-action="delete" data-id="${itemId}" title="Delete">🗑️</button>`;
     } else if (status === 'in_progress') {
@@ -122,13 +119,12 @@ document.addEventListener('DOMContentLoaded', async () => {
       // Update action buttons based on new status
       const actionsCell = row.querySelector('.actions-cell');
       if (actionsCell) {
-        actionsCell.innerHTML = generateActionCellContent(data.item_id, data.status);
-      }
-
-      if (data.local_chapter_id != null && data.local_folder_id != null) {
-        applyReaderLinkToRow(row, data.local_chapter_id, data.local_folder_id);
-      } else if (data.status === 'completed') {
-        applyReaderLinkToRow(row, null, null);
+        actionsCell.innerHTML = generateActionCellContent(
+          data.item_id,
+          data.status,
+          data.local_folder_id,
+          data.local_chapter_id
+        );
       }
     };
 
@@ -236,21 +232,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
   });
 
-  queueTableBody.addEventListener('click', e => {
-    if (e.target.closest('.action-btn')) return;
-    const tr = e.target.closest('tr');
-    if (!tr?.id?.startsWith('item-')) return;
-    if (!tr.classList.contains('queue-row--readable')) return;
-    const chapterId = tr.dataset.chapterId;
-    const folderId = tr.dataset.folderId;
-    if (chapterId && folderId) {
-      window.location.href = `/reader/series/${folderId}/chapters/${chapterId}`;
-    }
-  });
-
   // Add event delegation for individual item action buttons
   queueTableBody.addEventListener('click', async e => {
-    const button = e.target.closest('.action-btn');
+    const button = e.target.closest('button.action-btn');
     if (!button) return;
 
     const action = button.dataset.action;

--- a/internal/assets/web/static/js/download_manager.js
+++ b/internal/assets/web/static/js/download_manager.js
@@ -9,6 +9,20 @@ document.addEventListener('DOMContentLoaded', async () => {
   const pauseResumeBtn = document.getElementById('pause-resume-btn');
   let ws;
 
+  const applyReaderLinkToRow = (row, chapterId, folderId) => {
+    if (chapterId != null && folderId != null) {
+      row.dataset.chapterId = String(chapterId);
+      row.dataset.folderId = String(folderId);
+      row.classList.add('queue-row--readable');
+      row.title = 'Open in reader';
+    } else {
+      delete row.dataset.chapterId;
+      delete row.dataset.folderId;
+      row.classList.remove('queue-row--readable');
+      row.removeAttribute('title');
+    }
+  };
+
   const renderRow = item => {
     let row = document.getElementById(`item-${item.id}`);
     if (!row) {
@@ -32,6 +46,15 @@ document.addEventListener('DOMContentLoaded', async () => {
       <td>${item.provider_id}</td>
       <td class="actions-cell">${actionButtons}</td>
     `;
+    if (
+      item.status === 'completed' &&
+      item.local_chapter_id != null &&
+      item.local_folder_id != null
+    ) {
+      applyReaderLinkToRow(row, item.local_chapter_id, item.local_folder_id);
+    } else {
+      applyReaderLinkToRow(row, null, null);
+    }
     return row;
   };
 
@@ -100,6 +123,12 @@ document.addEventListener('DOMContentLoaded', async () => {
       const actionsCell = row.querySelector('.actions-cell');
       if (actionsCell) {
         actionsCell.innerHTML = generateActionCellContent(data.item_id, data.status);
+      }
+
+      if (data.local_chapter_id != null && data.local_folder_id != null) {
+        applyReaderLinkToRow(row, data.local_chapter_id, data.local_folder_id);
+      } else if (data.status === 'completed') {
+        applyReaderLinkToRow(row, null, null);
       }
     };
 
@@ -205,6 +234,18 @@ document.addEventListener('DOMContentLoaded', async () => {
         setTimeout(loadQueue, 500); // Give backend a moment before refreshing
       }
     });
+  });
+
+  queueTableBody.addEventListener('click', e => {
+    if (e.target.closest('.action-btn')) return;
+    const tr = e.target.closest('tr');
+    if (!tr?.id?.startsWith('item-')) return;
+    if (!tr.classList.contains('queue-row--readable')) return;
+    const chapterId = tr.dataset.chapterId;
+    const folderId = tr.dataset.folderId;
+    if (chapterId && folderId) {
+      window.location.href = `/reader/series/${folderId}/chapters/${chapterId}`;
+    }
   });
 
   // Add event delegation for individual item action buttons

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,7 +41,7 @@ func Load() (*Config, error) {
 
 	// Set default values
 	viper.SetDefault("port", 8080)
-	viper.SetDefault("scan_interval", 60)
+	viper.SetDefault("scan_interval", 0)
 	viper.SetDefault("database.path", "./mango.db")
 	viper.SetDefault("library.path", "./manga")
 	viper.SetDefault("plugins.path", "../mango-go-plugins")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -27,6 +27,9 @@ func TestLoadConfig(t *testing.T) {
 		if cfg.Library.Path != "./manga" {
 			t.Errorf("Expected default library path './manga', got '%s'", cfg.Library.Path)
 		}
+		if cfg.ScanInterval != 0 {
+			t.Errorf("Expected default scan_interval 0, got %d", cfg.ScanInterval)
+		}
 	})
 
 	t.Run("Loads from config file", func(t *testing.T) {
@@ -63,8 +66,8 @@ unknown_setting: "should be ignored"
 		if cfg.Library.Path != "/tmp/test-manga" {
 			t.Errorf("Expected library path '/tmp/test-manga', got '%s'", cfg.Library.Path)
 		}
-		if cfg.ScanInterval != 60 {
-			t.Errorf("Expected default scan interval of 60, got %d", cfg.ScanInterval)
+		if cfg.ScanInterval != 0 {
+			t.Errorf("Expected default scan interval of 0 when unset in file, got %d", cfg.ScanInterval)
 		}
 	})
 }

--- a/internal/core/app.go
+++ b/internal/core/app.go
@@ -14,7 +14,7 @@ import (
 	"github.com/vrsandeep/mango-go/internal/websocket"
 )
 
-const Version = "0.1.4" // Application version
+const Version = "0.1.5" // Application version
 
 // App holds the core components of the application that are shared
 // between the server and the CLI.

--- a/internal/downloader/worker.go
+++ b/internal/downloader/worker.go
@@ -87,17 +87,26 @@ func worker(id int, app *core.App, st *store.Store) {
 			log.Println(errMsg)
 			st.UpdateQueueItemStatus(job.ID, "failed", errMsg)
 		} else {
-			st.UpdateQueueItemStatus(job.ID, "completed", "Download finished successfully.")
-			// Trigger an incremental scan for the downloaded file
-			// Get the file path that was just created
 			cbzPath := getDownloadPath(app, st, job)
-
-			// Trigger incremental scan for the downloaded file
-			go func() {
-				if err := library.IncrementalLibrarySync(app, []string{cbzPath}); err != nil {
-					log.Printf("Failed to trigger incremental scan for downloaded file: %v", err)
+			if err := library.IncrementalLibrarySync(app, []string{cbzPath}); err != nil {
+				log.Printf("Failed incremental scan after download: %v", err)
+			}
+			var ch *models.Chapter
+			if looked, err := st.GetChapterByDiskPath(cbzPath); err != nil {
+				log.Printf("Lookup chapter after download: %v", err)
+			} else if looked != nil {
+				ch = looked
+				if err := st.UpdateDownloadQueueLocalChapter(job.ID, ch.ID, ch.FolderID); err != nil {
+					log.Printf("failed to link download queue item to library chapter: %v", err)
 				}
-			}()
+			}
+			st.UpdateQueueItemStatus(job.ID, "completed", "Download finished successfully.")
+			var chapPtr, folderPtr *int64
+			if ch != nil {
+				chapPtr = &ch.ID
+				folderPtr = &ch.FolderID
+			}
+			sendDownloaderProgressUpdate(app, job.ID, "Download finished successfully.", "completed", 100, true, chapPtr, folderPtr)
 		}
 	}
 }
@@ -225,7 +234,7 @@ func processDownload(app *core.App, st *store.Store, job *models.DownloadQueueIt
 		}
 
 		// Broadcast progress update via WebSocket
-		sendDownloaderProgressUpdate(app, job.ID, fmt.Sprintf("Downloaded page %d of %d", i+1, total), status, float64(progress), done)
+		sendDownloaderProgressUpdate(app, job.ID, fmt.Sprintf("Downloaded page %d of %d", i+1, total), status, float64(progress), done, nil, nil)
 	}
 
 	if err := zipWriter.Close(); err != nil {
@@ -323,7 +332,7 @@ func PauseQueueItem(app *core.App, st *store.Store, itemID int64) error {
 	}
 
 	// Broadcast pause status update
-	sendDownloaderProgressUpdate(app, itemID, "Download paused by user", "paused", progress, false)
+	sendDownloaderProgressUpdate(app, itemID, "Download paused by user", "paused", progress, false, nil, nil)
 
 	return nil
 }
@@ -343,7 +352,7 @@ func ResumeQueueItem(app *core.App, st *store.Store, itemID int64) error {
 	}
 
 	// Broadcast resume status update
-	sendDownloaderProgressUpdate(app, itemID, "Download resumed by user", "queued", progress, false)
+	sendDownloaderProgressUpdate(app, itemID, "Download resumed by user", "queued", progress, false, nil, nil)
 
 	return nil
 }
@@ -356,18 +365,20 @@ func RetryQueueItem(app *core.App, st *store.Store, itemID int64) error {
 	}
 
 	// Broadcast retry status update with progress reset to 0
-	sendDownloaderProgressUpdate(app, itemID, "Download retried by user", "queued", 0.0, false)
+	sendDownloaderProgressUpdate(app, itemID, "Download retried by user", "queued", 0.0, false, nil, nil)
 
 	return nil
 }
 
-func sendDownloaderProgressUpdate(app *core.App, itemID int64, message string, status string, progress float64, done bool) {
+func sendDownloaderProgressUpdate(app *core.App, itemID int64, message string, status string, progress float64, done bool, localChapterID, localFolderID *int64) {
 	app.WsHub().BroadcastJSON(models.ProgressUpdate{
-		JobID:    "downloader",
-		Message:  message,
-		Progress: progress,
-		ItemID:   itemID,
-		Status:   status,
-		Done:     done,
+		JobID:          "downloader",
+		Message:        message,
+		Progress:       progress,
+		ItemID:         itemID,
+		Status:         status,
+		Done:           done,
+		LocalChapterID: localChapterID,
+		LocalFolderID:  localFolderID,
 	})
 }

--- a/internal/models/downloader.go
+++ b/internal/models/downloader.go
@@ -22,5 +22,7 @@ type DownloadQueueItem struct {
 	Progress          int       `json:"progress"` // Percentage of download progress
 	Message           string    `json:"message"`  // Optional message for status updates
 	ProviderID        string    `json:"provider_id"`
+	LocalChapterID    *int64    `json:"local_chapter_id,omitempty"`
+	LocalFolderID     *int64    `json:"local_folder_id,omitempty"`
 	CreatedAt         time.Time `json:"created_at"`
 }

--- a/internal/models/progress.go
+++ b/internal/models/progress.go
@@ -8,4 +8,7 @@ type ProgressUpdate struct {
 	Status   string  `json:"status"` // e.g. "in_progress", "completed", "failed"
 	// Optional fields for more detailed updates
 	Done bool `json:"done"`
+	// Set when a download is linked to the library (reader URL)
+	LocalChapterID *int64 `json:"local_chapter_id,omitempty"`
+	LocalFolderID  *int64 `json:"local_folder_id,omitempty"`
 }

--- a/internal/store/chapter_store.go
+++ b/internal/store/chapter_store.go
@@ -62,6 +62,19 @@ func (s *Store) GetChapterByID(id int64, userID int64) (*models.Chapter, error) 
 	return &chapter, nil
 }
 
+// GetChapterByDiskPath returns the chapter row for an on-disk archive path, or nil if none.
+func (s *Store) GetChapterByDiskPath(diskPath string) (*models.Chapter, error) {
+	var c models.Chapter
+	err := s.db.QueryRow(`SELECT id, folder_id, path FROM chapters WHERE path = ?`, diskPath).Scan(&c.ID, &c.FolderID, &c.Path)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
 // GetAllChaptersByHash retrieves all chapters and maps them by their content hash for efficient lookup.
 func (s *Store) GetAllChaptersByHash() (map[string]ChapterInfo, error) {
 	rows, err := s.db.Query("SELECT id, path, content_hash, file_mtime, file_size FROM chapters")

--- a/internal/store/chapter_store_test.go
+++ b/internal/store/chapter_store_test.go
@@ -362,3 +362,47 @@ func TestChapterStore(t *testing.T) {
 	})
 
 }
+
+func TestGetChapterByDiskPath(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	s := store.New(db)
+
+	folder, err := s.CreateFolder("/library/DiskPath Series", "DiskPath Series", nil)
+	if err != nil {
+		t.Fatalf("CreateFolder: %v", err)
+	}
+	diskPath := "/library/DiskPath Series/vol1.cbz"
+	created, err := s.CreateChapter(folder.ID, diskPath, "hash_diskpath", 12, "thumb-dp")
+	if err != nil {
+		t.Fatalf("CreateChapter: %v", err)
+	}
+
+	t.Run("returns chapter when path matches", func(t *testing.T) {
+		got, err := s.GetChapterByDiskPath(diskPath)
+		if err != nil {
+			t.Fatalf("GetChapterByDiskPath: %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected non-nil chapter")
+		}
+		if got.ID != created.ID {
+			t.Errorf("ID: want %d, got %d", created.ID, got.ID)
+		}
+		if got.FolderID != folder.ID {
+			t.Errorf("FolderID: want %d, got %d", folder.ID, got.FolderID)
+		}
+		if got.Path != diskPath {
+			t.Errorf("Path: want %q, got %q", diskPath, got.Path)
+		}
+	})
+
+	t.Run("returns nil when no row matches", func(t *testing.T) {
+		got, err := s.GetChapterByDiskPath("/library/no/such/file.cbz")
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if got != nil {
+			t.Fatalf("expected nil chapter, got %+v", got)
+		}
+	})
+}

--- a/internal/store/download_store.go
+++ b/internal/store/download_store.go
@@ -84,7 +84,8 @@ func (s *Store) SubscribeToSeriesWithFolder(seriesTitle, seriesIdentifier, provi
 
 func (s *Store) GetDownloadQueue() ([]*models.DownloadQueueItem, error) {
 	query := `
-        SELECT id, series_title, chapter_title, chapter_identifier, provider_id, status, progress, message, created_at
+        SELECT id, series_title, chapter_title, chapter_identifier, provider_id, status, progress, message, created_at,
+               local_chapter_id, local_folder_id
         FROM download_queue ORDER BY created_at DESC
     `
 	rows, err := s.db.Query(query)
@@ -97,10 +98,19 @@ func (s *Store) GetDownloadQueue() ([]*models.DownloadQueueItem, error) {
 	for rows.Next() {
 		var item models.DownloadQueueItem
 		var msg sql.NullString
-		if err := rows.Scan(&item.ID, &item.SeriesTitle, &item.ChapterTitle, &item.ChapterIdentifier, &item.ProviderID, &item.Status, &item.Progress, &msg, &item.CreatedAt); err != nil {
+		var localChap, localFolder sql.NullInt64
+		if err := rows.Scan(&item.ID, &item.SeriesTitle, &item.ChapterTitle, &item.ChapterIdentifier, &item.ProviderID, &item.Status, &item.Progress, &msg, &item.CreatedAt, &localChap, &localFolder); err != nil {
 			return nil, err
 		}
 		item.Message = msg.String
+		if localChap.Valid {
+			v := localChap.Int64
+			item.LocalChapterID = &v
+		}
+		if localFolder.Valid {
+			v := localFolder.Int64
+			item.LocalFolderID = &v
+		}
 		items = append(items, &item)
 	}
 	return items, nil
@@ -109,7 +119,8 @@ func (s *Store) GetDownloadQueue() ([]*models.DownloadQueueItem, error) {
 // GetQueuedDownloadItems retrieves a limited number of items with a 'queued' status.
 func (s *Store) GetQueuedDownloadItems(limit int) ([]*models.DownloadQueueItem, error) {
 	query := `
-        SELECT id, series_title, chapter_title, chapter_identifier, provider_id, status, progress, message, created_at
+        SELECT id, series_title, chapter_title, chapter_identifier, provider_id, status, progress, message, created_at,
+               local_chapter_id, local_folder_id
         FROM download_queue WHERE status = 'queued' ORDER BY created_at ASC LIMIT ?
     `
 	rows, err := s.db.Query(query, limit)
@@ -122,10 +133,19 @@ func (s *Store) GetQueuedDownloadItems(limit int) ([]*models.DownloadQueueItem, 
 	for rows.Next() {
 		var item models.DownloadQueueItem
 		var msg sql.NullString
-		if err := rows.Scan(&item.ID, &item.SeriesTitle, &item.ChapterTitle, &item.ChapterIdentifier, &item.ProviderID, &item.Status, &item.Progress, &msg, &item.CreatedAt); err != nil {
+		var localChap, localFolder sql.NullInt64
+		if err := rows.Scan(&item.ID, &item.SeriesTitle, &item.ChapterTitle, &item.ChapterIdentifier, &item.ProviderID, &item.Status, &item.Progress, &msg, &item.CreatedAt, &localChap, &localFolder); err != nil {
 			return nil, err
 		}
 		item.Message = msg.String
+		if localChap.Valid {
+			v := localChap.Int64
+			item.LocalChapterID = &v
+		}
+		if localFolder.Valid {
+			v := localFolder.Int64
+			item.LocalFolderID = &v
+		}
 		items = append(items, &item)
 	}
 	return items, nil
@@ -134,17 +154,33 @@ func (s *Store) GetQueuedDownloadItems(limit int) ([]*models.DownloadQueueItem, 
 // GetDownloadQueueItem retrieves a single item from the download queue by ID.
 func (s *Store) GetDownloadQueueItem(id int64) (*models.DownloadQueueItem, error) {
 	query := `
-        SELECT id, series_title, chapter_title, chapter_identifier, provider_id, status, progress, message, created_at
+        SELECT id, series_title, chapter_title, chapter_identifier, provider_id, status, progress, message, created_at,
+               local_chapter_id, local_folder_id
         FROM download_queue WHERE id = ?
     `
 	var item models.DownloadQueueItem
 	var msg sql.NullString
-	err := s.db.QueryRow(query, id).Scan(&item.ID, &item.SeriesTitle, &item.ChapterTitle, &item.ChapterIdentifier, &item.ProviderID, &item.Status, &item.Progress, &msg, &item.CreatedAt)
+	var localChap, localFolder sql.NullInt64
+	err := s.db.QueryRow(query, id).Scan(&item.ID, &item.SeriesTitle, &item.ChapterTitle, &item.ChapterIdentifier, &item.ProviderID, &item.Status, &item.Progress, &msg, &item.CreatedAt, &localChap, &localFolder)
 	if err != nil {
 		return nil, err
 	}
 	item.Message = msg.String
+	if localChap.Valid {
+		v := localChap.Int64
+		item.LocalChapterID = &v
+	}
+	if localFolder.Valid {
+		v := localFolder.Int64
+		item.LocalFolderID = &v
+	}
 	return &item, nil
+}
+
+// UpdateDownloadQueueLocalChapter stores library IDs for a completed download (reader link).
+func (s *Store) UpdateDownloadQueueLocalChapter(id, chapterID, folderID int64) error {
+	_, err := s.db.Exec(`UPDATE download_queue SET local_chapter_id = ?, local_folder_id = ? WHERE id = ?`, chapterID, folderID, id)
+	return err
 }
 
 // UpdateQueueItemStatus changes an item's status and message.

--- a/internal/store/downloader_store_test.go
+++ b/internal/store/downloader_store_test.go
@@ -220,6 +220,10 @@ func TestGetDownloadQueueItem(t *testing.T) {
 		t.Errorf("Expected message 'Test message', got '%s'", item.Message)
 	}
 
+	if item.LocalChapterID != nil || item.LocalFolderID != nil {
+		t.Errorf("expected nil local library IDs when unset, got chapter=%v folder=%v", item.LocalChapterID, item.LocalFolderID)
+	}
+
 	// Test getting non-existent item
 	_, err = s.GetDownloadQueueItem(99999)
 	if err == nil {
@@ -616,5 +620,54 @@ func TestGetChapterIdentifiersInQueue(t *testing.T) {
 	}
 	if foundExpected != 2 {
 		t.Errorf("Expected to find 2 expected identifiers, found %d", foundExpected)
+	}
+}
+
+func TestUpdateDownloadQueueLocalChapter(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	s := store.New(db)
+
+	res, err := db.Exec(`INSERT INTO download_queue (series_title, chapter_title, chapter_identifier, provider_id, created_at, status) VALUES ('Series', 'Chapter', 'ch-id', 'prov', ?, 'completed')`, time.Now())
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	id, _ := res.LastInsertId()
+
+	if err := s.UpdateDownloadQueueLocalChapter(id, 42, 7); err != nil {
+		t.Fatalf("UpdateDownloadQueueLocalChapter: %v", err)
+	}
+
+	var chapID, folderID int64
+	err = db.QueryRow("SELECT local_chapter_id, local_folder_id FROM download_queue WHERE id = ?", id).Scan(&chapID, &folderID)
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if chapID != 42 || folderID != 7 {
+		t.Errorf("DB columns: want chapter=42 folder=7, got %d %d", chapID, folderID)
+	}
+
+	item, err := s.GetDownloadQueueItem(id)
+	if err != nil {
+		t.Fatalf("GetDownloadQueueItem: %v", err)
+	}
+	if item.LocalChapterID == nil || *item.LocalChapterID != 42 {
+		t.Errorf("GetDownloadQueueItem LocalChapterID: want 42, got %v", item.LocalChapterID)
+	}
+	if item.LocalFolderID == nil || *item.LocalFolderID != 7 {
+		t.Errorf("GetDownloadQueueItem LocalFolderID: want 7, got %v", item.LocalFolderID)
+	}
+
+	items, err := s.GetDownloadQueue()
+	if err != nil {
+		t.Fatalf("GetDownloadQueue: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("GetDownloadQueue: want 1 item, got %d", len(items))
+	}
+	if items[0].LocalChapterID == nil || *items[0].LocalChapterID != 42 {
+		t.Errorf("GetDownloadQueue LocalChapterID: want 42, got %v", items[0].LocalChapterID)
+	}
+	if items[0].LocalFolderID == nil || *items[0].LocalFolderID != 7 {
+		t.Errorf("GetDownloadQueue LocalFolderID: want 7, got %v", items[0].LocalFolderID)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -58,17 +58,21 @@ func main() {
 	// Start initial library scan
 	go app.JobManager().RunJob("library-sync", app)
 
-	// Start periodic full library scan once per day (24 hours)
-	go func() {
-		ticker := time.NewTicker(time.Duration(app.Config().ScanInterval) * time.Minute)
-		for range ticker.C {
-			log.Println("Performing periodic library scan...")
-			if err := app.JobManager().RunJob("library-sync", app); err != nil {
-				log.Printf("Warning: periodic library scan failed: %v", err)
+	// Periodic full library scan (disabled when scan_interval is 0)
+	if app.Config().ScanInterval > 0 {
+		go func() {
+			ticker := time.NewTicker(time.Duration(app.Config().ScanInterval) * time.Minute)
+			for range ticker.C {
+				log.Println("Performing periodic library scan...")
+				if err := app.JobManager().RunJob("library-sync", app); err != nil {
+					log.Printf("Warning: periodic library scan failed: %v", err)
+				}
+				log.Println("Periodic scan complete.")
 			}
-			log.Println("Periodic scan complete.")
-		}
-	}()
+		}()
+	} else {
+		log.Println("Periodic library scan disabled (scan_interval is 0).")
+	}
 
 	// Initialize plugin manager and discover plugins (lazy loading enabled)
 	pluginManager := plugins.NewPluginManager(app, app.Config().Plugins.Path)


### PR DESCRIPTION
1. Set default scanning interval to 0 -> Let Scan become an admin action. This is done, as I have noticed a high disk usage and memory usage when library scan runs.
2. Downloads manager should directly provide links to read the new ones